### PR TITLE
last minute edits

### DIFF
--- a/manuscript.Rnw
+++ b/manuscript.Rnw
@@ -180,7 +180,7 @@ manipulate, analyze, and visualize phylogenies.
 
 Advances in sequencing and computing technologies have lead to a revolution in
 systematic biology. The ability to routinely generate molecular datasets from
-any extant organism has allowed researchers to resolve long-running taxonomic
+any extant organism has allowed researchers to resolve long-standing taxonomic
 disputes and estimate phylogenies for previously understudied groups. In
 parallel, the ease with which phylogenies can be estimated has spurred the
 development of new phylogenetic comparative methods. These methods allow
@@ -259,7 +259,7 @@ APIs:
 \begin{enumerate}
 \item The \emph{taxonomy} used as the backbone of the tree, the Open Tree
   Taxonomy (OTT);
-\item The \emph{studies} and their associated trees some of which are chosen by
+\item The \emph{studies} and their associated trees, some of which are chosen by
   curators to assemble the synthetic tree;
 \item A \emph{taxonomic name resolution service} (TNRS) used to match taxon
   names to the Open Tree Taxonomy identifiers;
@@ -290,7 +290,7 @@ branch lengths to these topological subtrees \citep[e.g.,][]{Ksepka2015} or use
 topological trees to identify phylogenetically equivalent species to increase
 overlap between chronograms and species trait data \citep{Pennell2015}. Without
 branch lengths, these subtrees are nonetheless useful to illustrate relationships
-among species, or to map a trait on a phylogeny for instance.
+among species, or to map traits on a phylogeny.
 
 %% any examples available?
 
@@ -307,11 +307,9 @@ taxonomic information (i.e., monotypic taxon).
 
 The package is well-documented, and includes two package
 vignettes (documents that demonstrate the use of the package and contain executable
-R code)
-%as well as per-function documentation
-. There is also an extensive
-test-suite that covers both the internal functions that \texttt{rotl} uses to
-connect to OTL and public functions users apply to access and process data.
+R code). There is also an extensive test-suite that covers both the internal
+functions that \texttt{rotl} uses to connect to OTL and public functions users
+apply to access and process data.
 
 
 \section{Demonstrations}
@@ -321,7 +319,7 @@ connect to OTL and public functions users apply to access and process data.
 \label{sec:get-relationships}
 
 To get the relationships among a set of taxa from the Open Tree, the taxa first
-needs to be matched against the OTL taxonomy (OTT) using the TNRS. This step
+need to be matched against the OTL taxonomy (OTT) using the TNRS. This step
 retrieves the identifiers that will be used to extract the relationships for the
 set of requested taxa.
 
@@ -393,7 +391,7 @@ available through the output of the function
 \texttt{studies\_properties}. Typically, users will want to search for studies
 or trees based on taxon names (or their OTT identifiers), but other
 criteria such as the title of the publication can be used. Here we demonstrate
-how to look for and retrieve a tree for studies focusing on the family Felidae
+how to look for and retrieve trees for studies focusing on the family Felidae
 (Figure~\ref{fig:plot_cats}).
 
 <<get_cats, purl=FALSE, fig.cap="Tree from \\citealt{Johnson2006} obtained from OTL">>=
@@ -447,10 +445,10 @@ rOpenSci-developed packge \texttt{TreeBase} \citep{Boettiger2012TB} allows users
 to access phylogenies stored in treeBASE (\url{www.treebase.org}).
 \texttt{rotl} contributes to this initiative, and greatly extends the number of
 taxa for which phylogenetic data can be retrieved within R, while allowing the
-data from OTL can be combined with other sources easily.
+data from OTL to be combined with other sources easily.
 
 The package vignettes provide two demonstrations of the integration of a
-phylogeny and data associated the taxa it represents. Specifically, the ``Data
+phylogeny and data associated with the taxa it represents. Specifically, the ``Data
 mashups'' vignette provides an example of how data associated with tip-taxa can
 be gathered and visualized. Another vignette titled ``meta-analysis''
 demonstrates how a complete analysis, including the gathering of data and a
@@ -545,7 +543,7 @@ information available and re-usable.
 license. Stable versions are available from the CRAN repository
 (\url{https://cran.r-project.org/package=rotl}), and development versions are
 available from GitHub (\url{https://github.com/ropensci/rotl}). The package is
-under active development, and authors welcome bug reports of feature requests
+under active development, and authors welcome bug reports or feature requests
 via the GitHub repository.  The source for this manuscript is available on
 GitHub (\url{https://github.com/fmichonneau/rotl-ms}).
 

--- a/rotl-manuscript.bib
+++ b/rotl-manuscript.bib
@@ -311,7 +311,7 @@ year = {2015},
     address = {Boca Raton, Florida},
     year = {2015},
     edition = {2nd},
-    note = {ISBN 978-1498716963},
+    note = {{ISBN 978-1498716963}},
     url = {http://yihui.name/knitr/},
   }
 @article {Knuth1984,


### PR DESCRIPTION
Very minor.

Not sure what the policy of citing "Submitted" papers is. For the Pennell 2015 paper there is a biorxiv version available that I noted in the bibliography (but didn't point out explicitly):

```
%% this is only submitted. maybe cite biorxiv version?
%% http://biorxiv.org/content/early/2015/08/20/024992
@article{Pennell2015,
author = {Pennell, Matthew W and FitzJohn, Richard G and Cornell, William K},
journal = {Methods in Ecology and Evolution},
title = {{A simple approach for maximizing the overlap of phylogenetic and comparative data}},
volume = {submitted},
year = {2015}
}
```

There are 2 or 3 more "Submitted" papers cited; might want to check on that.

NOTE: I didn't update `manuscript.pdf`; it seems that it is reorganized from what `make` produces.
